### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,13 +146,13 @@ except TimeoutError:
 
 
 [docs]: http://pyddp.readthedocs.org/en/latest/ "pyddp documentation"
-[downloads badge]: https://pypip.in/download/pyddp/badge.svg "Downloads"
+[downloads badge]: https://img.shields.io/pypi/dm/pyddp.svg "Downloads"
 [egg badge]: https://pypip.in/egg/pyddp/badge.svg "Egg Status"
-[license badge]: https://pypip.in/license/pyddp/badge.svg "License"
+[license badge]: https://img.shields.io/pypi/l/pyddp.svg "License"
 [travisci]:https://travis-ci.org/foxdog-studios/pyddp "Continuous Integration"
 [travisci badge]: https://travis-ci.org/foxdog-studios/pyddp.svg "Build Status"
 [meteor]: https://www.meteor.com/ "Meteor"
 [pypi]: https://pypi.python.org/pypi/pyddp/ "pydpp on PyPI"
-[version badge]: https://pypip.in/version/pyddp/badge.svg "Latest Version"
+[version badge]: https://img.shields.io/pypi/v/pyddp.svg "Latest Version"
 [virtualenv]: http://virtualenv.readthedocs.org/en/latest/ "virtualenv"
-[wheel badge]: https://pypip.in/wheel/pyddp/badge.svg "Wheel Status"
+[wheel badge]: https://img.shields.io/pypi/wheel/pyddp.svg "Wheel Status"


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pyddp))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pyddp`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.